### PR TITLE
GA-97: Fix sorting categories by alphabetical

### DIFF
--- a/packages/evershop/src/modules/catalog/graphql/types/Category/Category.resolvers.js
+++ b/packages/evershop/src/modules/catalog/graphql/types/Category/Category.resolvers.js
@@ -82,7 +82,6 @@ module.exports = {
               INNER JOIN product p ON p.uuid = pc.product_id
               WHERE p.status = true AND p.visibility = true AND pc.category_id = c.uuid
             ) >= 1
-          ORDER BY c.is_popular DESC, c.sort_order ASC
       `);
 
       const supportedCountries = supportedCountryQueryResult.rows || [];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Description

Current
Currently, when users enter a keyword to search for destinations, the system returns results and sorts them based on priority (which Tech is handling). As a result, countries with names closer to the keyword may be listed after countries with higher priority. 

For example: Argentina has a higher priority than Germany, so when entering the keyword ‘Ge', Argentina will appear before Germany, even though Germany starts with 'Ge’. 

Open image-20240807-033244.png
image-20240807-033244.png
Acceptance criteria
Results should be sorted in alphabetical order and start with the searched keyword.

If multiple results start with the same keyword, for example, the keyword is 'ge' including 'Germany' and 'Georgia':

We have the character following 'ge' in 'Germany' is 'r', while in 'Georgia' it is 'o'.
→ Georgia should be listed before Germany because 'o' comes before 'r' alphabetically.

If the next characters of each result are the same, continue checking subsequent characters until a difference is found.

If there are no results starting with the keyword, display the results that contain the keyword and sort those results in alphabetical order. If yes, show results start with keyword first, then results contain keyword.

Note: This approach ensures that the search results are displayed in a consistent and user-friendly alphabetical order.

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
